### PR TITLE
- add ErrorAs[T](), EnvExists(), fixtures.UnsetEnv()

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,9 @@
+package goxp
+
+import "errors"
+
+func ErrorAs[T error](err error) (T, bool) {
+	var ee T
+	ok := errors.As(err, &ee)
+	return ee, ok
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,19 @@
+package goxp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type myError struct{}
+
+func (err *myError) Error() string { return "myerror" }
+
+func TestErrorAs(t *testing.T) {
+	e := &myError{}
+
+	ee, ok := ErrorAs[*myError](e)
+	require.True(t, ok)
+	require.Equal(t, e, ee)
+}

--- a/fixtures/env.go
+++ b/fixtures/env.go
@@ -4,9 +4,9 @@ import (
 	"encoding/base64"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/whitekid/goxp/fx"
-	"github.com/whitekid/goxp/log"
 )
 
 // Env environment fixture
@@ -14,36 +14,57 @@ func Env(key, value string) Teardown {
 	old, exists := os.LookupEnv(key)
 	os.Setenv(key, value)
 
-	cleared := false
+	var once sync.Once
 
 	return func() {
-		if cleared {
-			return
-		}
-
-		if exists {
-			os.Setenv(key, old)
-		} else {
-			os.Unsetenv(key)
-		}
-
-		cleared = true
+		once.Do(func() {
+			if exists {
+				os.Setenv(key, old)
+			} else {
+				os.Unsetenv(key)
+			}
+		})
 	}
 }
 
 // Envs multiple environments fixture
 func Envs(envs map[string]string) Teardown {
-	log.Debugf("envs = %+v", envs)
-	teardownsMap := fx.MapValues(envs, func(k, v string) Teardown {
-		log.Debugf("%s = %s", k, v)
+	teardowns := fx.MapValues(envs, func(k, v string) Teardown {
 		return Env(k, v)
 	})
 
-	return Chain(fx.Values(teardownsMap)...)
+	return Chain(fx.Values(teardowns)...)
 }
 
 // JSONEnv json environment fixture
 func JSONEnv(key, value string) Teardown {
 	encoded := base64.RawStdEncoding.EncodeToString([]byte(strings.TrimSpace(value)))
 	return Env(key, encoded)
+}
+
+// UnsetEnv ensure environment was unset and return recover environment recover teardown
+func UnsetEnv(key string) Teardown {
+	value, exists := os.LookupEnv(key)
+	if exists {
+		os.Unsetenv(key)
+	}
+
+	var once sync.Once
+
+	return func() {
+		once.Do(func() {
+			if exists {
+				os.Setenv(key, value)
+			} else {
+				os.Unsetenv(key)
+			}
+		})
+	}
+}
+
+// UnsetEnvs multiple environments fixture
+func UnsetEnvs(envs []string) Teardown {
+	return Chain(fx.Map(envs, func(k string) Teardown {
+		return UnsetEnv(k)
+	})...)
 }

--- a/fixtures/file.go
+++ b/fixtures/file.go
@@ -2,6 +2,7 @@ package fixtures
 
 import (
 	"os"
+	"sync"
 )
 
 // TempFile tempfile
@@ -15,5 +16,7 @@ func TempFile(dir, pattern string, callbacks ...func(string)) func() {
 		callback(f.Name())
 	}
 
-	return func() { os.Remove(f.Name()) }
+	var once sync.Once
+
+	return func() { once.Do(func() { os.Remove(f.Name()) }) }
 }

--- a/fixtures/file_test.go
+++ b/fixtures/file_test.go
@@ -1,1 +1,19 @@
 package fixtures
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/whitekid/goxp"
+)
+
+func TestTempFile(t *testing.T) {
+	var name string
+	teardown := TempFile(t.TempDir(), "test-*.tmp", func(n string) { name = n })
+	defer teardown()
+
+	require.True(t, goxp.FileExists(name))
+
+	teardown()
+	require.False(t, goxp.FileExists(name))
+}

--- a/fixtures/timer.go
+++ b/fixtures/timer.go
@@ -18,16 +18,12 @@ func Timer(format string, args ...interface{}) Teardown {
 	timerLoggerOnce.Do(func() { timerLogger = log.New() })
 	start := time.Now()
 
-	cleared := false
+	var once sync.Once
 
 	return func() {
-		if cleared {
-			return
-		}
-
-		span := time.Since(start)
-		timerLogger.Debugf("%s takes %s", span, fmt.Sprintf(format, args...))
-
-		cleared = true
+		once.Do(func() {
+			span := time.Since(start)
+			timerLogger.Debugf("%s takes %s", span, fmt.Sprintf(format, args...))
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
 	go.uber.org/zap v1.24.0
-	golang.org/x/exp v0.0.0-20221212164502-fae10dda9338
+	golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15
 	golang.org/x/net v0.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -251,8 +251,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20221212164502-fae10dda9338 h1:OvjRkcNHnf6/W5FZXSxODbxwD+X7fspczG7Jn/xQVD4=
-golang.org/x/exp v0.0.0-20221212164502-fae10dda9338/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15 h1:5oN1Pz/eDhCpbMbLstvIPa0b/BEQo6g6nwV3pLjfM6w=
+golang.org/x/exp v0.0.0-20221217163422-3c43f8badb15/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/misc.go
+++ b/misc.go
@@ -31,3 +31,9 @@ func JsonRecode(dest, src interface{}) error {
 
 	return nil
 }
+
+// EnvExists return true if environment variabes exists
+func EnvExists(k string) bool {
+	_, exists := os.LookupEnv(k)
+	return exists
+}


### PR DESCRIPTION
- fixtures:
  * wrap sync.Once() to prevent run multiple teardown
  * add UnsetEnv()